### PR TITLE
Set member default, fixes merge issue (closes #69)

### DIFF
--- a/carbonplan_forest_risks/load/cmip.py
+++ b/carbonplan_forest_risks/load/cmip.py
@@ -47,6 +47,9 @@ def cmip(
             raise ValueError('must specify scenario')
         if model is None:
             raise ValueError('must specify model')
+        if member is None:
+            member = members[model]   
+            
 
         path = setup.loading(store)
 

--- a/carbonplan_forest_risks/load/cmip.py
+++ b/carbonplan_forest_risks/load/cmip.py
@@ -48,8 +48,8 @@ def cmip(
         if model is None:
             raise ValueError('must specify model')
         if member is None:
-            member = members[model]   
-            
+            member = members[model]
+
 
         path = setup.loading(store)
 


### PR DESCRIPTION
The [member default](https://github.com/carbonplan/forest-risks/commit/e2b6a50cd5972fc68c12efae00e5f92e3acfb381#diff-2f392a9e48a6293298e3ccc5d73c74ac636e591d2e85a2a11c0f140a94fc52efR47) was added for the biomass model updates but then accidentally [removed in a later merge](https://github.com/carbonplan/forest-risks/commit/4b4d6387eea4187eba0839687cb282d814abb486#diff-2f392a9e48a6293298e3ccc5d73c74ac636e591d2e85a2a11c0f140a94fc52efL50-L51).